### PR TITLE
Update dump strategy

### DIFF
--- a/bin/dump-boring-reads.py
+++ b/bin/dump-boring-reads.py
@@ -5,15 +5,27 @@ import sys
 
 from Bio import SeqIO
 import pysam
+import khmer
+
 
 def match(record, seq):
     refrseq = str(seq[record.pos:record.pos+record.rlen].seq)
     return refrseq == records.seq
 
+
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--seqid', metavar='SEQ',
                         help='dump reads not mapped to SEQ')
+    parser.add_argument('--genomemask', metavar='FILE', help='dump reads with '
+                        'median k-mer abundance ≥ 1 in the specified genome; '
+                        'if both --seqid and --genomemask are declared, reads '
+                        'passing either filter will be kept')
+    parser.add_argument('--maskmemory', metavar='SIZE', default=2e9,
+                        help='memory to be occupied by genome mask; default is'
+                        ' 2e9 (2G)')
+    parser.add_argument('--mask-k', metavar='K', default=31, help='k size '
+                        'for genome mask')
     parser.add_argument('--out', type=argparse.FileType('w'),
                         help='output file; default is terminal (stdout)')
     parser.add_argument('--dry-run', action='store_true',
@@ -21,6 +33,7 @@ def get_parser():
     parser.add_argument('fasta')
     parser.add_argument('bam')
     return parser
+
 
 def main(args):
     if args.dry_run:
@@ -30,26 +43,39 @@ def main(args):
     with open(args.fasta, 'r') as seqfile:
         seqs = {record.id: record for record in SeqIO.parse(seqfile, 'fasta')}
 
+    if args.genomemask:
+        genomemask = khmer.Countgraph(args.mask_k, int(args.maskmemory / 4), 4)
+        genomemask.consume_fasta(args.genomemask)
+
     bam = pysam.AlignmentFile(args.bam, 'rb')
     for i, record in enumerate(bam):
         if (i+1) % 10000 == 0:
             print('...processed', i, 'records', file=sys.stderr)
 
-        if args.seqid:
-            if record.reference_id < 0 or bam.get_reference_name(record.reference_id) != args.seqid:
-                continue
-
         if record.is_secondary or record.is_supplementary:
             continue
 
-        matchcigar = '{:d}M'.format(record.rlen)
-        if record.cigarstring != matchcigar:
+        pass_seqid_filter = True
+        if args.seqid:
+            if record.reference_id < 0 or \
+               bam.get_reference_name(record.reference_id) != args.seqid:
+                pass_seqid_filter = False
+        pass_genomemask_filter = True
+        if args.genomemask:
+            count = genomemask.get_median_count(record.seq)[0]
+            pass_genomemask_filter = count < 1
+        if not pass_seqid_filter and not pass_genomemask_filter:
             continue
 
-        seq = seqs[bam.get_reference_name(record.tid)]
-        refrseq = str(seq[record.pos:record.pos+record.rlen].seq)
-        if refrseq.upper() != record.seq.upper():
-            print('@', record.qname, '\n', record.seq, '\n+\n', record.qual, sep='', file=args.out)
+        matchcigar = '{:d}M'.format(record.rlen)
+        if record.cigarstring == matchcigar:
+            seq = seqs[bam.get_reference_name(record.tid)]
+            refrseq = str(seq[record.pos:record.pos+record.rlen].seq)
+            if refrseq.upper() == record.seq.upper():
+                continue
+
+        print('@', record.qname, '\n', record.seq, '\n+\n', record.qual,
+              sep='', file=args.out)
 
 if __name__ == '__main__':
     main(get_parser().parse_args())

--- a/kevlar/dump.py
+++ b/kevlar/dump.py
@@ -14,14 +14,12 @@ import kevlar
 
 def subparser(parser):
     subparsers = parser.add_subparsers(dest='cmd')
-    subparser = subparsers.add_parser('dump')
-    subparser.add_argument('--infmt', metavar='FMT', choices=['bam, fastq'],
-                           help='format of input file; "bam" or "fastq"')
+    subparser = subparsers.add_parser('dump'))
     subparser.add_argument('--out', metavar='FILE',
                            type=argparse.FileType('w'),
                            help='output file; default is terminal (stdout)')
     subparser.add_argument('refr', help='reference sequence in Fasta format')
-    subparser.add_argument('reads', help='reads in Fastq or BAM format')
+    subparser.add_argument('reads', help='read alignments in BAM format')
 
 
 def main(args, log=sys.stderr):


### PR DESCRIPTION
The original "dump boring reads" strategy included an option to filter based on sequence IDs (e.g., get reads associated with chr19). This was implemented with a naive seqid check. The problem with this is that it discards all unmapped reads--reads that have potentially useful information.

We addressed this by using an ostensibly more flexibly strategy: loading the chromosome of interest (from the reference genome assembly) into a countgraph and keeping reads whose median k-mer count is ≥ 1. This seemed like a good idea at the time, except that 2 to 3 carefully placed mismatches will disqualify otherwise perfectly fine reads.

So now, we have the following strategy.

- user specifies seqid of chromosome of interest (e.g. chr19)
- user provides a "genome mask" with the entire genome sequence, minus the chromosome of interest (e.g. hg-without-chr19.fa)
- discard all reads that match the reference genome perfectly (as has always been done)
- of remaining reads, keep those that satisfy either of the two following criteria:
    - match the user-specified seqid
    - are absent from the user-specified genome mask

Also, it looks like I introduced a bug with the CIGAR handling since the first version. :-/ This PR fixes that bug.