### PR TITLE
Troubleshooting CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - 3.5
 install:
     - pip install --upgrade pip setuptools pytest pep8 cython
-    - pip install git+https://github.com/standage/pysam.git
+    - pip install git+https://github.com/pysam-developers/pysam.git
     - pip install git+https://github.com/dib-lab/khmer.git
     - pip install .
 script:


### PR DESCRIPTION
The pysam developers suggested that https://github.com/pysam-developers/pysam/pull/345 may have solved this issue. If so, it would be better to install from the canonical repo rather than a fork. Once they cut a new release we can revert to installing from PyPI.