### PR TITLE
Add tests for kevlar.fasta module, fix parse_seq_dict bug

### DIFF
--- a/kevlar/fasta.py
+++ b/kevlar/fasta.py
@@ -35,7 +35,7 @@ def parse_seq_dict(data):
     """Load sequences from a Fasta file into a dictionary."""
     seqs = dict()
     for defline, sequence in parse(data):
-        seqid = defline[1:].split(' ')[0]
+        seqid = defline[1:].replace('\t', ' ').split(' ')[0]
         assert seqid not in seqs
         seqs[seqid] = sequence
     return seqs

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016 The Regents of the University of California
+#
+# This file is part of kevlar (http://github.com/standage/kevlar) and is
+# licensed under the MIT license: see LICENSE.
+# -----------------------------------------------------------------------------
+
+import pytest
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+import kevlar
+
+
+@pytest.fixture
+def bogusseqs():
+    seq = '>seq1\nACGT\n>seq2 yo\nGATTACA\nGATTACA\n>seq3\tdescrip\nATGATGTGA'
+    return seq.split('\n')
+
+
+def test_parse(bogusseqs):
+    seqs = { defline: seq for defline, seq in kevlar.fasta.parse(bogusseqs) }
+    assert seqs == {
+        '>seq1': 'ACGT',
+        '>seq2 yo': 'GATTACAGATTACA',
+        '>seq3\tdescrip': 'ATGATGTGA',
+    }
+
+
+def test_seq_dict(bogusseqs):
+    d = kevlar.fasta.parse_seq_dict(bogusseqs)
+    assert d == {
+        'seq1': 'ACGT',
+        'seq2': 'GATTACAGATTACA',
+        'seq3': 'ATGATGTGA',
+    }

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -22,7 +22,7 @@ def bogusseqs():
 
 
 def test_parse(bogusseqs):
-    seqs = { defline: seq for defline, seq in kevlar.fasta.parse(bogusseqs) }
+    seqs = {defline: seq for defline, seq in kevlar.fasta.parse(bogusseqs)}
     assert seqs == {
         '>seq1': 'ACGT',
         '>seq2 yo': 'GATTACAGATTACA',


### PR DESCRIPTION
The parse_seq_dict function wasn't handling tabs in deflines well. In fixing this, added some tests for the entire module.